### PR TITLE
create a dedicated session if needed

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -154,6 +154,9 @@ def setup_worker(worker_id, args):
     return {'cookies': _COOKIES}
 
 
+_SHOTS = []
+
+
 async def create_shot(session=None):
     """
     Create/upload a new Page Shot shot.
@@ -162,6 +165,8 @@ async def create_shot(session=None):
         session = ClientSession(cookies=_COOKIES)
 
     path = "data/{}/test.com".format(make_uuid())
+    if path not in _SHOTS:
+        _SHOTS.append(path)
     path_pageshot = urljoin(SERVER_URL, path)
     data = make_example_shot()
     headers = {'content-type': 'application/json'}
@@ -171,10 +176,16 @@ async def create_shot(session=None):
         return r
 
 
-async def read_shot(session, path):
+async def read_shot(session=None, path=None):
     """
     Read a shot, given a specific URL fragment (for example: "data/{UUID}/test.com")
     """
+    if session is None:
+        session = ClientSession(cookies=_COOKIES)
+
+    if path is None:
+        path = _SHOTS[-1]
+
     path_pageshot = urljoin(SERVER_URL, path)
     headers = {'content-type': 'application/json'}
 

--- a/utils.py
+++ b/utils.py
@@ -154,10 +154,13 @@ def setup_worker(worker_id, args):
     return {'cookies': _COOKIES}
 
 
-async def create_shot(session):
+async def create_shot(session=None):
     """
     Create/upload a new Page Shot shot.
     """
+    if session is None:
+        session = ClientSession(cookies=_COOKIES)
+
     path = "data/{}/test.com".format(make_uuid())
     path_pageshot = urljoin(SERVER_URL, path)
     data = make_example_shot()


### PR DESCRIPTION
The setup() function predates the creation of the worker's dedicated session.

If we want to use create_shot() in it, we have to create a fresh session in it. This change will make both use cases work by making session an optional argument